### PR TITLE
Fix: Nextjs Build error on Reply schema unmatched with Interface IReply

### DIFF
--- a/components/ReplyCard.tsx
+++ b/components/ReplyCard.tsx
@@ -134,7 +134,7 @@ const ReplyCard = ( { currentUser, reply } : ReplyCardProps ) => {
             {/* Reply Form */}
             { showReplyForm && 
                 (
-                    <ReplyForm currentUser={currentUser} parentCommentID={reply.parent} replyingTo={reply.user.username}/>
+                    <ReplyForm currentUser={currentUser} parentCommentID={reply.parent as string} replyingTo={reply.user.username}/>
                 ) 
             }
 

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -26,7 +26,7 @@ export interface IReply {
     score: number
     replyingTo: string
     user: IUser
-    parent: string
+    parent: IComment | string
     createdAt: Date
     updatedAt: Date
 }


### PR DESCRIPTION
### Description
There is a build-time error on Reply schema for the `parent` attribute which is a reference to a Comment schema. 

Interface and FE referring the reference as string as we are only dealing with Object_ID, however, schema understands it as IComment (or Comment schema).

Hotfix has been merged.

Test passed ✅ Attempt build on local is successful
Test passed ✅ Running dev-server app still working as expected