### PR TITLE
[Production] Merge: Fix the api/replies/parent/[id] fetching

### DIFF
--- a/pages/api/replies/parent/[id].tsx
+++ b/pages/api/replies/parent/[id].tsx
@@ -5,6 +5,8 @@
  import type { NextApiRequest, NextApiResponse } from 'next'
  import { dbConnect } from "../../../../utils/connection";
  import { ResponseFunctions } from '../../../../interfaces';
+ import User from '../../../../models/User';
+ import Comment from '../../../../models/Comment';
  import Reply from '../../../../models/Reply';
  
  const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -23,7 +25,13 @@
          GET: async (req: NextApiRequest, res: NextApiResponse) => {
              // Connect to database.
              await dbConnect();
- 
+
+             // Fetch all users object.
+             const users = await User.find({}).catch(exception);
+             
+             // Fetch all comments objects.
+             const comments = await Comment.find({}).populate('user').catch(exception);
+
              // Fetch all parent's replies objects.
              const parentReplies = await Reply.find({ parent: id }).populate('user').catch(exception);
              

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps<{
   // Caching config.
   context.res.setHeader(
     'Cache-Control',
-    'no-cache, max-age=0, must-revalidate'
+    'public, s-maxage=5, stale-while-revalidate=10'
   )
 
   // Get current environment variable.


### PR DESCRIPTION
There is an issue in production when fetching replies of parent-comment, in particular the connection to database is unable to fetched the data due to the fact the User and Comment object (reference-relationship) have not yet been fetched.

This update should fix the production-issue.