### PR TITLE
[Fix] - 'Rubik' font does not get loaded properly on production-build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  optimizeFonts: false,
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,22 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument;

--- a/styles/config/_variables.scss
+++ b/styles/config/_variables.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap');
-
 :root {
     --max-width: 375px;
 


### PR DESCRIPTION
### Description

Currently, the production-build does not load the font properly despite the `@import` font tag has been added correctly into the `/config/_variables.scss`.

Solution:
- Create `/pages/_document.tsx` file which is the root-document as per the [next-js documentation](https://nextjs.org/docs/messages/no-page-custom-font).
- Add the `<Head>...</Head>` tag which will load the google-font.
- Remove the `@import` font tag has been added correctly into the `/config/_variables.scss`.
- Update nextjs-config to disable the font-optimisation as per the [documentation](https://nextjs.org/docs/basic-features/font-optimization#disabling-optimization).

### Testing

✅ Re-run build and start production-build (draft) and the build displays the font is now showing properly.

<img width="1512" alt="Screen Shot 2022-10-08 at 1 01 53 AM" src="https://user-images.githubusercontent.com/31334333/194611586-dad01c90-390b-4de2-863e-1970830947f0.png">
